### PR TITLE
Add flip and unflip textmojis

### DIFF
--- a/emoji substitutions.plist
+++ b/emoji substitutions.plist
@@ -6398,5 +6398,17 @@
     <key>shortcut</key>
     <string>:booty:</string>
   </dict>
+  <dict>
+    <key>phrase</key>
+    <string>(╯°□°）╯︵ ┻━┻</string>
+    <key>shortcut</key>
+    <string>:flip:</string>
+  </dict>
+  <dict>
+    <key>phrase</key>
+    <string>┬─┬ノ( º _ ºノ)</string>
+    <key>shortcut</key>
+    <string>:unflip:</string>
+  </dict>
 </array>
 </plist>

--- a/emojis-km6.kmmacros
+++ b/emojis-km6.kmmacros
@@ -1098,6 +1098,8 @@
 :millenial:,🐍
 :millenials:,🐍🐍🐍
 :booty:,🍑
+:flip:,(╯°□°）╯︵ ┻━┻
+:unflip:,┬─┬ノ( º _ ºノ)
 </string>
 						<key>Variable</key>
 						<string>emoji_list</string>


### PR DESCRIPTION
Added a trick (flip) and a treat (unflip) textmoji (I'm trying to keep it 🎃-themed).

What also works great is setting up Slackbot to reply with :unflip: when someone flips a table, which may very well frustrate them further. 😄

<img width="211" alt="Slackbot keeping things tidy" src="https://cloud.githubusercontent.com/assets/754567/19828143/68adca34-9e0a-11e6-9fa1-4e3ba0dc16b4.png">
