### PR TITLE
Fail macmoji script if any command fails

### DIFF
--- a/scripts/macmoji
+++ b/scripts/macmoji
@@ -2,6 +2,9 @@
 #
 # Install or uninstall the text replacements
 
+# fail script if any command fails
+set -e
+
 cd "$(dirname "$(realpath "$0")")";
 
 DATE=$(date +%s)


### PR DESCRIPTION
Due to #35 failing, I think it would be in the best interest of users to fail the script early instead of attempting to continue executing the script with an unpredictable result due to the failure.

By using the `set -e` flag, we tell the bash script to fail if any of the commands it runs fails.

https://stackoverflow.com/questions/19622198/what-does-set-e-mean-in-a-bash-script