### PR TITLE
Use homebrew-bundle to install dependencies

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "coreutils"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
 1. Just run `./scripts/macmoji install` (or even `uninstall`!)
 (Thanks [mshick](https://github.com/mshick)!)
 
+**Note:** This will install `coreutils` from homebrew if homebrew is available on your system.
+
 #### Gif instructions:
 ![How to "install" Macmoji](https://github.com/warpling/Macmoji/blob/master/gifs/how%20to%20install.gif?raw=true)
 
@@ -65,12 +67,6 @@ Keyboard text substitutions sync across iCloud. I haven't found a way to disable
 
 #### 😠 Sometimes it just stops working in some applications
 No clue. Beats me. Have a hunch why? I'd love to hear it!
-
-#### ☹️ `realpath: command not found`
-You may need to install [Homebrew](https://brew.sh/) and then run the following to install `coreutils`. Please comment on [issue #35](https://github.com/warpling/Macmoji/issues/35) if you experience this!
-```
-brew install coreutils
-```
 
 ## Change Log
 

--- a/scripts/macmoji
+++ b/scripts/macmoji
@@ -35,6 +35,8 @@ contains () {
 install() {
   echo "Installing Macmoji text replacements..."
 
+  [ -x /usr/local/bin/brew ] && brew bundle --no-lock --file=../Brewfile
+
   PK_LAST=$(${SQLITE} "${USER_DICTIONARY}" "SELECT Z_PK FROM ZUSERDICTIONARYENTRY ORDER BY Z_PK DESC LIMIT 1;")
 
   pk=$PK_LAST


### PR DESCRIPTION
Minor change to use `brew bundle` that is now built-in to Homebrew to install `coreutils` if Homebrew is available.